### PR TITLE
Parse the decompressed JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,8 @@ dependencies = [
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lz4 1.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -378,6 +380,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ edition = "2018"
 dirs = "2.0.2"
 glob = "0.3.0"
 lz4 = "1.23.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"


### PR DESCRIPTION
This uses serde to parse the JSON, which allows it to print the actual open URLs rather than just the raw JSON.

The program  also now filters out any `about:` URLs, like `about:home` or `about:newtab`, which aren't real URLs.